### PR TITLE
Bump jGroups to a working version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.jgroups</groupId>
             <artifactId>jgroups</artifactId>
-            <version>4.0.16-SNAPSHOT</version>
+            <version>4.1.1.Final</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Since 4.0.16-SNAPSHOT seems to be AWOL I've updated the dependency to 4.1.1.Final.